### PR TITLE
export as a function (by default) rather than a string

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,20 +8,38 @@ Require files relative to your project root.
 npm install --save rootrequire
 ```
 
-## Use
+## Usage
+
+### Function
+
+```javascript
+var root = require('rootrequire');
+var someLib = require(root('/lib/some-lib.js'));
+
+console.log(root.path); // /path/to/your/project/dir
+```
+
+The leading directory separator is optional when using the `root` function e.g. the following are equivalent:
+
+```javascript
+var someLib = require(root('/lib/some-lib.js'));
+var someLib = require(root('lib/some-lib.js'));
+```
+
+### Path
 
 ```js
-var
-  root = require('rootrequire'),
-  myLib = require(root + '/path/to/lib.js');
+var root = require('rootrequire').path;
+var someLib = require(root + '/lib/some-lib.js');
+
+console.log(root); // /path/to/your/project/dir
 ```
 
 ## Why?
 
-* You can move files around more easily than you can with relative paths like `../../lib/my-lib.js`
+* You can move files around more easily than you can with relative paths like `../../lib/my-lib.js`.
 * Every file documents your app's directory structure for you. You'll know exactly where to look for things.
 * Dazzle your coworkers.
-
 
 ## Learn JavaScript with Eric Elliott
 

--- a/index.js
+++ b/index.js
@@ -6,16 +6,29 @@
 // Usage:
 // Anywhere in your project:
 
-var root = require('root'),
-  someLib = require(root + '/lib/some-lib.js');
+// Function:
 
-console.log(root); // /path/to/your/project/dir
+  var root = require('rootrequire');
+  var someLib = require(root('/lib/some-lib.js'));
+  console.log(root.path); // /path/to/your/project/dir
+
+// Path:
+
+  var root = require('rootrequire').path;
+  var someLib = require(root + '/lib/some-lib.js');
+  console.log(root); // /path/to/your/project/dir
 
 */
 
 'use strict';
 
 var path = require('path');
+var $root = path.join(__dirname, '/../..');
 
-module.exports = path.resolve(__dirname + '/../..');
+function root ($path) {
+  return path.join($root, $path);
+}
 
+root.path = $root;
+
+module.exports = root;


### PR DESCRIPTION
This is a very handy module, but I always end up wrapping it in a function (for convenience/correctness), which gets tedious:

``` javascript
var path  = require('path');
var $root = require('rootrequire');

function root ($path) {
    return path.join($root, $path);
}

var libPath = root('/path/to/lib');
```

Exporting it as a string value doesn't allow the function to be attached (in ES5). Exporting it as a String object doesn't play well with `console.log`. Exporting it as a function allows easy access to both e.g.:

``` javascript
var root  = require('rootrequire'); // function
var $root = require('rootrequire').path; // path
```

The only downside I can see is that this is a breaking change.
